### PR TITLE
_notif-close element is now an anchor instead of div

### DIFF
--- a/assets/javascripts/templates/notif_tmpl.coffee
+++ b/assets/javascripts/templates/notif_tmpl.coffee
@@ -1,6 +1,6 @@
 notif = (title, html) ->
   html = html.replace /<a/g, '<a class="_notif-link"'
-  """<h5 class="_notif-title">#{title}</h5>#{html}<div class="_notif-close"></div>"""
+  """<h5 class="_notif-title">#{title}</h5>#{html}<a href="#" class="_notif-close"></a>"""
 
 textNotif = (title, message) ->
   notif title, """<p class="_notif-text">#{message}"""

--- a/assets/javascripts/views/misc/notif.coffee
+++ b/assets/javascripts/views/misc/notif.coffee
@@ -48,7 +48,7 @@ class app.views.Notif extends app.View
     return
 
   onClick: (event) =>
-    unless event.target.tagName is 'A'
+    if event.target.tagName isnt 'A' or event.target.classList.contains('_notif-close')
       $.stopEvent(event)
       @hide()
     return


### PR DESCRIPTION
Now closing a notification can be done with keyboard navigation and extensions like Vimium that look for anchor elements to act on.

Old behaviour is still retained when clicking on other anchors inside the notification or the notification itself.