### PR TITLE
Make devdocs WCAG AA Colour Contrast Compliant

### DIFF
--- a/assets/stylesheets/global/_variables.scss
+++ b/assets/stylesheets/global/_variables.scss
@@ -13,7 +13,7 @@ $documentBackground: #fafafa;
 
 $textColor: #333;
 $textColorLight: #666;
-$textColorLighter: #999;
+$textColorLighter: #707070;
 
 $inputFocusBorder: #35b5f4;
 
@@ -30,8 +30,8 @@ $selectionText: #fff;
 
 $highlightBackground: #fffdcd;
 
-$linkColor: #0082c6;
-$linkColorHover: #0072c5;
+$linkColor: #0073b3;
+$linkColorHover: #005f93;
 
 $headerBackground: #f0f0f0;
 $headerBorder: #d9d9d9;

--- a/assets/stylesheets/global/_variables.scss
+++ b/assets/stylesheets/global/_variables.scss
@@ -24,7 +24,7 @@ $focusText: #000;
 $loadingText: #ccc;
 $splashText: #ccc;
 
-$selectionBackground: #398df0;
+$selectionBackground: #3076c9;
 $selectionBorder: #196fc2;
 $selectionText: #fff;
 


### PR DESCRIPTION
Obviously some of these changes are subjective but they are objective in making sure that devdocs is over the 4.5 WCAG AA colour contrast ratio in normal mode.

Pull request is related to but only fixes the contrast issues in normal mode mentioned in https://github.com/Thibaut/devdocs/issues/305

You can use the Axe plugin to verify the change:
https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd