### PR TITLE
Fix A11y issues with lang attribute and lack of label on the search box

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Page not found</title>

--- a/public/500.html
+++ b/public/500.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Error</title>

--- a/views/app.erb
+++ b/views/app.erb
@@ -3,7 +3,7 @@
     <a class="_home-link"></a>
     <a class="_menu-link"></a>
     <form class="_search">
-      <input type="search" class="_search-input" placeholder="Search&hellip;" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" maxlength="30">
+      <input type="search" class="_search-input" placeholder="Search&hellip;" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false" maxlength="30" aria-label="Search">
       <a class="_search-clear"></a>
       <div class="_search-tag"></div>
     </form>

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html<%= ' manifest="/manifest.appcache"' if App.production? %> prefix="og: http://ogp.me/ns#">
+<html<%= ' manifest="/manifest.appcache"' if App.production? %> prefix="og: http://ogp.me/ns#" lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,shrink-to-fit=no">

--- a/views/other.erb
+++ b/views/other.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">


### PR DESCRIPTION
Fix a couple of accessibility issue in devdocs, namely:
* Lack of a lang attribute on the html tag
* Lack of a label for the search field (placeholder text can't be read by most screen readers)

Related to issue https://github.com/Thibaut/devdocs/issues/305