### PR TITLE
Added Lua Nginx Module documentation

### DIFF
--- a/assets/javascripts/views/pages/lua_nginx_module.coffee
+++ b/assets/javascripts/views/pages/lua_nginx_module.coffee
@@ -1,0 +1,8 @@
+#= require views/pages/base
+
+# this may be used for all GitHub pages
+
+class app.views.LuaNginxModulePage extends app.views.BasePage
+  prepare: ->
+    @highlightCode @findAll('div.highlight-source-lua pre'), 'lua'
+    return

--- a/lib/docs/filters/lua_nginx_module/clean_html.rb
+++ b/lib/docs/filters/lua_nginx_module/clean_html.rb
@@ -1,0 +1,22 @@
+module Docs
+  class LuaNginxModule
+    class CleanHtmlFilter < Filter
+      def call
+        type = nil
+        doc.children.each do |node|
+          if node.name == 'h1'
+            section = node.content.strip
+            type = section.in?(['Directives', 'Nginx API for Lua']) ? section : nil
+          end
+
+          if type == nil || (node.name == 'ul' && node.previous_element.name == 'h1') || node.content.strip == 'Back to TOC'
+            node.remove()
+          elsif node.name == 'h2'
+            node["id"] = /^user-content-(.+)/.match(node.css('a.anchor').first["id"])[1]
+          end
+        end
+        doc
+      end
+    end
+  end
+end

--- a/lib/docs/filters/lua_nginx_module/entries.rb
+++ b/lib/docs/filters/lua_nginx_module/entries.rb
@@ -1,0 +1,17 @@
+module Docs
+  class LuaNginxModule
+    class EntriesFilter < Docs::EntriesFilter
+      def additional_entries
+        type = nil 
+
+        doc.children.each_with_object [] do |node, entries|
+          if node.name == 'h1'
+            type = node.content.strip
+          elsif node.name == 'h2'
+            entries << [ node.content, node["id"], type ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/docs/scrapers/lua_nginx_module.rb
+++ b/lib/docs/scrapers/lua_nginx_module.rb
@@ -1,0 +1,19 @@
+module Docs
+  class LuaNginxModule < UrlScraper
+    self.type = 'LuaNginxModule'
+    self.root_path = 'README.markdown'
+
+    html_filters.push 'lua_nginx_module/clean_html', 'lua_nginx_module/entries'
+
+    options[:container] = '#readme > article'
+
+    options[:attribution] = <<-HTML
+      Copyright (C) 2009-2015, by Xiaozhe Wang (chaoslawful) <a href="mailto:chaoslawful@gmail.com">chaoslawful@gmail.com</a>.<br>
+      Copyright (C) 2009-2015, by Yichun "agentzh" Zhang (章亦春) <a href="mailto:agentzh@gmail.com">agentzh@gmail.com</a>, CloudFlare Inc.<br>
+      Licensed under the BSD License.
+    HTML
+
+    self.release = '0.10.0'
+    self.base_url = 'https://github.com/openresty/lua-nginx-module/tree/v0.10.0/'
+  end
+end


### PR DESCRIPTION
These commits adds the documentation for Lua Nginx Module, a popular extension to Nginx to enable Lua scripting. I didn't find any previous scraper that takes a GitHub markdown file as input, so maybe there is some way remove some code from filters.

I also added Lua syntax highlighting to the Prism library.