### PR TITLE
Version Lua documentation (5.1, 5.2, 5.3)

### DIFF
--- a/lib/docs/scrapers/lua.rb
+++ b/lib/docs/scrapers/lua.rb
@@ -1,8 +1,6 @@
 module Docs
   class Lua < UrlScraper
     self.type = 'lua'
-    self.release = '5.3'
-    self.base_url = 'http://www.lua.org/manual/5.3/'
     self.root_path = 'manual.html'
 
     html_filters.push 'lua/clean_html', 'lua/entries'
@@ -13,5 +11,20 @@ module Docs
       &copy; 1994&ndash;2015 Lua.org, PUC-Rio.<br>
       Licensed under the MIT License.
     HTML
+
+    version '5.1' do
+      self.release = '5.1'
+      self.base_url = 'http://www.lua.org/manual/5.1/'
+    end
+
+    version '5.2' do
+      self.release = '5.2'
+      self.base_url = 'http://www.lua.org/manual/5.2/'
+    end
+
+    version '5.3' do
+      self.release = '5.3'
+      self.base_url = 'http://www.lua.org/manual/5.3/'
+    end
   end
 end


### PR DESCRIPTION
Added documentations for previous versions of Lua (5.1 release is still widely used as it is the only supported by LuaJIT).