### PR TITLE
Adding influxdb documentation

### DIFF
--- a/lib/docs/filters/influxdb/clean_html.rb
+++ b/lib/docs/filters/influxdb/clean_html.rb
@@ -1,0 +1,18 @@
+module Docs
+  class Influxdb
+    class CleanHtmlFilter < Filter
+      def call
+        doc = @doc.at_css('#page-content')
+
+        # Re-position the page header
+        header = at_css('.page--body h1')
+        doc.children.first.add_next_sibling header
+
+        # Remove the contribution
+        at_css('.page--contribute').remove
+
+        doc 
+      end
+    end
+  end
+end

--- a/lib/docs/filters/influxdb/entries.rb
+++ b/lib/docs/filters/influxdb/entries.rb
@@ -1,0 +1,19 @@
+module Docs
+  class Influxdb
+    class EntriesFilter < Docs::EntriesFilter
+      
+      def get_name
+        at_css('#page-title h1').content
+      end
+
+      def get_type
+        # This is kinda hacky, we are fetching the current type from
+        # the url, we are asumming that the url pattern is
+        # category/page or category
+        path = current_url.relative_path_from(base_url)
+        path.split('/').first.titleize
+      end
+
+    end
+  end
+end

--- a/lib/docs/filters/influxdb/entries.rb
+++ b/lib/docs/filters/influxdb/entries.rb
@@ -11,7 +11,7 @@ module Docs
         # the url, we are asumming that the url pattern is
         # category/page or category
         path = current_url.relative_path_from(base_url)
-        path.split('/').first.titleize
+        "InfluxDB: #{path.split('/').first.titleize}"
       end
 
     end

--- a/lib/docs/scrapers/influxdb.rb
+++ b/lib/docs/scrapers/influxdb.rb
@@ -2,8 +2,8 @@ module Docs
   class Influxdb < UrlScraper
     self.name = 'InfluxDB'
     self.type = 'influxdb'
-    self.release = '0.9'
-    self.base_url = 'https://docs.influxdata.com/influxdb/v0.9/'
+    self.release = '0.10'
+    self.base_url = 'https://docs.influxdata.com/influxdb/v0.10/'
     
     html_filters.push 'influxdb/entries', 'influxdb/clean_html'
 

--- a/lib/docs/scrapers/influxdb.rb
+++ b/lib/docs/scrapers/influxdb.rb
@@ -1,0 +1,15 @@
+module Docs
+  class Influxdb < UrlScraper
+    self.name = 'InfluxDB'
+    self.type = 'influxdb'
+    self.release = '0.9'
+    self.base_url = 'https://docs.influxdata.com/influxdb/v0.9/'
+    
+    html_filters.push 'influxdb/entries', 'influxdb/clean_html'
+
+    options[:attribution] = <<-HTML
+      &copy; 2010&ndash;2015 InfluxData<br>
+      Licensed under the MIT license.
+    HTML
+  end
+end


### PR DESCRIPTION
Hi,

I have added documentation to influxdb, I have some open questions/ideas:

1. I have scraped the documentation using UrlScrapper - but the documentation is open source - https://github.com/influxdata/docs.influxdata.com, I didn't know what is the preferred way for this url scrapping or file scrapping?
2. I removed the contribution guideline from everypage, which is something like this:
``
This documentation is open source. See a typo? Please, open an issue.
``
I think it will be nice to add to the attribution, what do you think?
3. It will be really easy to make this scrapper generic and support all InfluxData docs (for example Kapacitor, which I am interested in) - do you want me to do this?
4. The styling for h2 headers and etc, aren't applied, after I header "_influx" to _base.scss it's fixed, but I saw that the "new documentation guideline" and the commit log suggests that only @Thibaut only edits it..


That's it :)

BTW - I REALLY LOVE DEVDOCS, IT MAKES MY LIFE EASIER :+1: 