### PR TITLE
Add `ex` as alias for Elixir

### DIFF
--- a/assets/javascripts/models/entry.coffee
+++ b/assets/javascripts/models/entry.coffee
@@ -49,6 +49,7 @@ class app.models.Entry extends app.Model
     'backbone': 'bb'
     'c++': 'cpp'
     'coffeescript': 'cs'
+    'elixir': 'ex'
     'javascript': 'js'
     'jquery': '$'
     'knockout.js': 'ko'


### PR DESCRIPTION
Because `.ex` is the extension used by Elixir's source files.