### PR TITLE
Fix resizing left side list in Firefox

### DIFF
--- a/assets/javascripts/views/layout/resizer.coffee
+++ b/assets/javascripts/views/layout/resizer.coffee
@@ -4,7 +4,6 @@ class app.views.Resizer extends app.View
   @events:
     dragstart: 'onDragStart'
     dragend: 'onDragEnd'
-    drag: 'onDrag'
 
   @isSupported: ->
     'ondragstart' of document.createElement('div') and !app.isMobile()
@@ -36,6 +35,7 @@ class app.views.Resizer extends app.View
     @style.removeAttribute('disabled')
     event.dataTransfer.effectAllowed = 'link'
     event.dataTransfer.setData('Text', '')
+    window.addEventListener("dragover", @onDrag);
     return
 
   onDrag: (event) =>
@@ -48,6 +48,7 @@ class app.views.Resizer extends app.View
     return
 
   onDragEnd: (event) =>
+    window.removeEventListener("dragover", @onDrag);
     value = event.pageX or (event.screenX - window.screenX)
     if @lastDragValue and not (@lastDragValue - 5 < value < @lastDragValue + 5) # https://github.com/Thibaut/devdocs/issues/265
       value = @lastDragValue


### PR DESCRIPTION
In Firefox drag events, different coordinates are always zeros. This
change will add window level dragover listener inside dragstart
handler of the resizer and removes the listener in dragend handler.
With this change resizing the list works for Firefox and for
Chrome.