### PR TITLE
Add link to Emacs package

### DIFF
--- a/assets/javascripts/templates/pages/about_tmpl.coffee
+++ b/assets/javascripts/templates/pages/about_tmpl.coffee
@@ -70,6 +70,7 @@ app.templates.aboutPage = -> """
     <li><a href="https://sublime.wbond.net/packages/DevDocs">Sublime Text plugin</a>
     <li><a href="https://atom.io/packages/devdocs">Atom plugin</a>
     <li><a href="https://github.com/gruehle/dev-docs-viewer">Brackets extension</a>
+    <li><a href="https://github.com/xuchunyang/DevDocs.el">Emacs Package</a>
   </ul>
   <p>You can also use <a href="http://fluidapp.com">Fluid</a> to turn DevDocs into a real OS X app, or <a href="https://apps.ubuntu.com/cat/applications/fogger/">Fogger</a> on Ubuntu.
 


### PR DESCRIPTION
I made a small Emacs package to launch a DevDocs search from Emacs, the search pattern is built base on some context (programming language, selection and symbol at cursor etc).

The link is https://github.com/xuchunyang/DevDocs.el