### PR TITLE
Add Pig Documentation

### DIFF
--- a/assets/stylesheets/pages/_simple.scss
+++ b/assets/stylesheets/pages/_simple.scss
@@ -27,6 +27,7 @@
 ._markdown,
 ._mocha,
 ._mongoose,
+._pig,
 ._sinon,
 ._typescript,
 ._webpack {

--- a/lib/docs/filters/pig/clean_html.rb
+++ b/lib/docs/filters/pig/clean_html.rb
@@ -1,0 +1,26 @@
+module Docs
+  class Pig
+    class CleanHtmlFilter < Filter
+      def call
+        @doc = at_css('#content')
+
+        css('.pdflink').remove
+
+        css('a[name]').each do |node|
+          node.next_element['id'] = node['name']
+        end
+
+        css('h2', 'h3').each do |node|
+          node.remove_attribute 'class'
+        end
+
+        css('table').each do |node|
+          node.remove_attribute 'cellspacing'
+          node.remove_attribute 'cellpadding'
+        end
+
+        doc
+      end
+    end
+  end
+end

--- a/lib/docs/filters/pig/entries.rb
+++ b/lib/docs/filters/pig/entries.rb
@@ -1,0 +1,33 @@
+module Docs
+  class Pig
+    class EntriesFilter < Docs::EntriesFilter
+
+      def include_default_entry?
+        false
+      end
+
+      def get_type
+        at_css('h1').content
+      end
+
+      def additional_entries
+        case slug
+          when 'basic', 'cmds', 'func'
+            nodes = css('h3')
+          when 'cont'
+            nodes = css('h2, #macros + div > h3')
+          when 'test'
+            nodes = css('h2, #diagnostic-ops + div > h3')
+          when 'perf'
+            nodes = css('h2, #optimization-rules + div > h3, #specialized-joins + div > h3')
+          else
+            nodes = css('h2')
+        end
+
+        nodes.each_with_object [] do |node, entries|
+          entries << [node.content, node['id'], get_type]
+        end
+      end
+    end
+  end
+end

--- a/lib/docs/scrapers/pig.rb
+++ b/lib/docs/scrapers/pig.rb
@@ -1,0 +1,39 @@
+module Docs
+  class Pig < UrlScraper
+    self.name = 'Pig'
+    self.type = 'pig'
+    self.links = {
+      home: 'https://pig.apache.org/'
+    }
+
+    html_filters.push 'pig/clean_html', 'pig/entries'
+
+    options[:skip] = %w( pig-index.html )
+
+    options[:skip_patterns] = [
+      /\Aapi/,
+      /\Ajdiff/
+    ]
+
+    options[:attribution] = <<-HTML
+      &copy; 2007&ndash;2016 Apache Software Foundation<br>
+      Licensed under the Apache Software License version 2.0.
+    HTML
+
+    version '0.15.0' do
+      self.release = '0.15.0'
+      self.base_url = "http://pig.apache.org/docs/r#{release}/"
+    end
+
+    version '0.14.0' do
+      self.release = '0.14.0'
+      self.base_url = "http://pig.apache.org/docs/r#{release}/"
+    end
+
+    version '0.13.0' do
+      self.release = '0.13.0'
+      self.base_url = "http://pig.apache.org/docs/r#{release}/"
+    end
+
+  end
+end


### PR DESCRIPTION
I did not include the [Pig logo](https://pig.apache.org/images/pig-logo.gif) because it would **not** look good shrunk to 16x16 and I couldn't find anything else that was logo-ish. I can try and find a generic cartoon pig that's freely licensed if it's absolutely required.

The documentation is all Apache Licensed.

https://pig.apache.org/