### PR TITLE
Hide/Show sidebar when dragging it or typing into the serarch input

### DIFF
--- a/assets/javascripts/app/settings.coffee
+++ b/assets/javascripts/app/settings.coffee
@@ -79,6 +79,15 @@ class app.Settings
     catch
     return
 
+  hasLayout: (name) ->
+    try
+      layout = (Cookies.get(LAYOUT_KEY) || '').split(' ')
+      $.arrayDelete(layout, '')
+      console.log(layout)
+      return layout.indexOf(name) isnt -1
+    catch
+    return false
+
   setSize: (value) ->
     try
       Cookies.set SIZE_KEY, value, path: '/', expires: 1e8

--- a/assets/javascripts/views/layout/document.coffee
+++ b/assets/javascripts/views/layout/document.coffee
@@ -46,6 +46,27 @@ class app.views.Document extends app.View
     app.appCache?.updateInBackground()
     return
 
+  hideSidebar: (saveLayout = true) ->
+    sidebarHidden = app.el.classList.contains(HIDE_SIDEBAR_CLASS)
+    return if sidebarHidden
+    app.el.classList.add(HIDE_SIDEBAR_CLASS)
+    return unless saveLayout
+    app.settings.setLayout(HIDE_SIDEBAR_CLASS, true)
+    app.appCache?.updateInBackground()
+    return
+
+  showSidebar: (saveLayout = true) ->
+    sidebarHidden = app.el.classList.contains(HIDE_SIDEBAR_CLASS)
+    return unless sidebarHidden
+    app.el.classList.remove(HIDE_SIDEBAR_CLASS)
+    return unless saveLayout
+    app.settings.setLayout(HIDE_SIDEBAR_CLASS, false)
+    app.appCache?.updateInBackground()
+    return
+
+  hasSidebar: ->
+    return !app.el.classList.contains(HIDE_SIDEBAR_CLASS) && !app.settings.hasLayout(HIDE_SIDEBAR_CLASS)
+
   setTitle: (title) ->
     @el.title = if title then "DevDocs - #{title}" else 'DevDocs API Documentation'
 

--- a/assets/javascripts/views/layout/resizer.coffee
+++ b/assets/javascripts/views/layout/resizer.coffee
@@ -55,6 +55,12 @@ class app.views.Resizer extends app.View
   onDragEnd: (event) =>
     $.off(window, 'dragover', @onDrag)
     value = event.pageX or (event.screenX - window.screenX)
+    if value <= 5
+      app.document.hideSidebar()
+      return
+    else if !app.document.hasSidebar()
+      app.document.showSidebar()
+
     if @lastDragValue and not (@lastDragValue - 5 < value < @lastDragValue + 5) # https://github.com/Thibaut/devdocs/issues/265
       value = @lastDragValue
     @resize(value, true)

--- a/assets/javascripts/views/search/search.coffee
+++ b/assets/javascripts/views/search/search.coffee
@@ -65,11 +65,14 @@ class app.views.Search extends app.View
   onInput: =>
     return if not @value? or # ignore events pre-"ready"
               @value is @input.value
+
     @value = @input.value
 
     if @value.length
+      app.document.showSidebar(false)
       @search()
     else
+      app.document.hideSidebar(false) unless app.document.hasSidebar()
       @clear()
     return
 


### PR DESCRIPTION
Added the new interactions that could trigger hiding/showing of the sidebar.
If you drag it all the way to the edge it will hide, then if you drag it to the right it will show again.
If you deliberately hide the sidebar then type into the search input, the sidebar will be shown. If you delete the text, the sidebar will be hidden again. This behavior does not apply if the sidebar is already opened.
If I missed something or the behavior is not what you were expecting let me know and I will change it. 
It may be that you'll want me to refactor one or two things, just let me know.

This additions are related to #341 