### PR TITLE
Fix URL#relative_path_to

### DIFF
--- a/lib/docs/core/url.rb
+++ b/lib/docs/core/url.rb
@@ -100,7 +100,7 @@ module Docs
           result << '/' if result != '.'
         end
       else
-        dest_dir.parent.relative_path_from(base_dir).join(::File.basename(dest)).to_s
+        dest_dir.parent.relative_path_from(base_dir).join(dest.split('/').last).to_s
       end
     end
 

--- a/test/lib/docs/core/url_test.rb
+++ b/test/lib/docs/core/url_test.rb
@@ -394,6 +394,14 @@ class DocsUrlTest < MiniTest::Spec
         assert_equal 'file', url.relative_path_to('http://example.com/file?query#frag')
       end
 
+      it "returns 'some:file' with 'http://example.com/some:file'" do
+        assert_equal 'some:file', url.relative_path_to('http://example.com/some:file')
+      end
+
+      it "returns 'some:file' with 'http://example.com/some:file?query#frag'" do
+        assert_equal 'some:file', url.relative_path_to('http://example.com/some:file?query#frag')
+      end
+
       it "returns nil with '/file'" do
         assert_nil url.relative_path_to('/file')
       end


### PR DESCRIPTION
Replace File.basename in URL#relative_path_to because it doesn't handle special characters in URLs well.
Since this branch will only be executed when `dest` does not end with `'/'`, there is no need to handle this special case, so a simple `dest.split('/').last` should suffice.
Fixes #402 completely, together with 2813cf9be32cf6f2dc69abca75069084d871aeb6.