### PR TITLE
add support for CMake

### DIFF
--- a/lib/docs/filters/cmake/clean_html.rb
+++ b/lib/docs/filters/cmake/clean_html.rb
@@ -1,0 +1,43 @@
+module Docs
+  class Cmake
+    class CleanHtmlFilter < Filter
+      # since each property category has its own entry redirect to that one instead
+      URL_MAPPING = {
+        '/manual/cmake-properties.7#properties-of-global-scope' => '/../cmake-properties-of-global-scope/',
+        '/manual/cmake-properties.7#properties-on-directories' => '/../cmake-properties-on-directories/',
+        '/manual/cmake-properties.7#target-properties' => '/../cmake-properties-on-targets/',
+        '/manual/cmake-properties.7.html#properties-on-tests' => '/../cmake-properties-on-tests/',
+        '/manual/cmake-properties.7.html#properties-on-source-files' => '/../cmake-properties-on-source-files/',
+        '/manual/cmake-properties.7.html#properties-on-cache-entries' => '/../cmake-properties-on-cache-entries/',
+        '/manual/cmake-properties.7.html#properties-on-installed-files' => '/../cmake-properties-on-installed-files/',
+        '/manual/cmake-properties.7.html#deprecated-properties-on-directories' => '/../cmake-deprecated-properties-on-directories/',
+        '/manual/cmake-properties.7.html#deprecated-properties-on-targets' => '/../cmake-deprecated-properties-on-targets/',
+        '/manual/cmake-properties.7.html#deprecated-properties-on-source-files' => '/../cmake-deprecated-properties-on-source-files/'
+      }
+
+      def call
+        css('.headerlink').remove
+        if root_page?
+          css('#release-notes').remove
+          css('#index-and-search').remove
+          return doc
+        end
+        css('.toc-backref').each do |link|
+          link.replace(link.text)
+        end
+        css('#contents').remove
+
+        # change urls pointing to entries which don't have a default entry
+        css('a').each do |link|
+          URL_MAPPING.each do |key, value|
+            if link['href'].end_with? key
+              link['href'] = link['href'][0..-(key.length + 1)] + value
+            end
+          end
+        end
+
+        doc
+      end
+    end
+  end
+end

--- a/lib/docs/filters/cmake/entries.rb
+++ b/lib/docs/filters/cmake/entries.rb
@@ -1,0 +1,64 @@
+module Docs
+  class Cmake
+    class EntriesFilter < Docs::EntriesFilter
+      MISCELLANEOUS = {
+        'manual/cmake.1' => 'CMake',
+        'manual/ctest.1' => 'CTest',
+        'manual/cpack.1' => 'CPack',
+        'manual/cmake-gui.1' => 'CMake GUI',
+        'manual/ccmake.1' => 'CCMake',
+        'manual/cmake-buildsystem.7' => 'Buildsystem',
+        'manual/cmake-commands.7' => 'Commands',
+        'manual/cmake-compile-features.7' => 'Compile Features',
+        'manual/cmake-developer.7' => 'Developer',
+        'manual/cmake-generator-expressions.7' => 'Generator Expressions',
+        'manual/cmake-generators.7' => 'Generators',
+        'manual/cmake-language.7' => 'Language',
+        'manual/cmake-modules.7' => 'Modules',
+        'manual/cmake-packages.7' => 'Packages',
+        'manual/cmake-policies.7' => 'Policies',
+        'manual/cmake-properties.7' => 'Properties',
+        'manual/cmake-qt.7' => 'Qt',
+        'manual/cmake-toolchains.7' => 'Toolchains',
+        'manual/cmake-variables.7' => 'Variables' }
+
+      GROUPS = {
+        'command' => 'Commands',
+        'policy' => 'Policies',
+        'prop_gbl' => 'Properties of Global Scope',
+        'prop_dir' => 'Properties on Directories',
+        'prop_tgt' => 'Properties on Targets',
+        'prop_test' => 'Properties on Tests',
+        'prop_sf' => 'Properties on Source Files',
+        'prop_cache' => 'Properties on Cache Entries',
+        'prop_inst' => 'Properties on Installed Files',
+        'variable' => 'Variables' }
+
+      def get_name
+        if MISCELLANEOUS.key?(slug)
+          return MISCELLANEOUS[slug]
+        end
+        parts = slug.split('/')
+        name = parts.drop(1).first
+        if name == ''
+          return slug
+        end
+        if parts.first == 'command'
+          name += '()'
+        end
+        name
+      end
+
+      def get_type
+        if MISCELLANEOUS.key?(slug)
+          return 'Miscellaneous'
+        end
+        parts = slug.split('/')
+        if GROUPS.key?(parts.first)
+          return GROUPS[parts.first]
+        end
+        slug
+      end
+    end
+  end
+end

--- a/lib/docs/scrapers/cmake.rb
+++ b/lib/docs/scrapers/cmake.rb
@@ -1,0 +1,32 @@
+module Docs
+  class Cmake < UrlScraper
+    self.name = 'CMake'
+    self.slug = 'cmake'
+    self.type = 'cmake'
+    self.release = '3.5'
+    self.base_url = 'https://cmake.org/cmake/help/v3.5/'
+
+    options[:skip] = %w(
+      release/index.html
+      genindex.html
+      search.html
+    )
+
+    options[:only_patterns] = [
+     /manual/,
+     /command/,
+     /policy/,
+     /prop_/,
+     /variable/
+    ]
+
+    options[:container] = '.body'
+
+    html_filters.push 'cmake/clean_html', 'cmake/entries'
+
+    options[:attribution] = <<-HTML
+      &copy; 2000&ndash;2016 Kitware, Inc.<br>
+      Licensed under the BSD 3-clause License.
+    HTML
+  end
+end


### PR DESCRIPTION
This PR adds support for [CMake](https://cmake.org/overview/). The CMake icons is available from their git repo in many format and resolutions: https://cmake.org/gitweb?p=cmake.git;a=tree;f=Source/QtDialog;h=2f0773ebdcd3fc299299fc6dea0fc63c834924db;hb=refs/heads/master e.g.:
* 32px: https://cmake.org/gitweb?p=cmake.git;a=blob_plain;f=Source/QtDialog/CMakeSetup32.png;hb=refs/heads/master

I assume that since the documentation is being generated from the docblocks within the source code that it is covered by the same license (BSD 3-clause, https://cmake.org/licensing/). This seems to be the case for several of the existing documentations as well.

The index page is not very pretty, but that's the same for the upstream doc :wink: I kept all the miscellaneous documentations but the focus is on the `Commands`, `Policies`, `Properties`, and `Variables`. I tried to strip unnecessary stuff (e.g. release notes, the index, toc above the content) and it looks reasonable to me at this point.

Since this is my first contribution to this project and I am not writing Ruby code usually I am happy for any feedback.