### PR TITLE
Add Docker documentation

### DIFF
--- a/assets/stylesheets/pages/_simple.scss
+++ b/assets/stylesheets/pages/_simple.scss
@@ -19,6 +19,7 @@
 ._apache_pig,
 ._chai,
 ._cordova,
+._docker,
 ._gnu,
 ._grunt,
 ._haxe,

--- a/lib/docs/filters/docker/clean_html.rb
+++ b/lib/docs/filters/docker/clean_html.rb
@@ -1,0 +1,23 @@
+module Docs
+  class Docker
+    class CleanHtmlFilter < Filter
+      def call
+        if root_page?
+          @doc = at_css('.tabs-content')
+        else
+          @doc = at_css('#content')
+        end
+
+        if not at_css('h1')
+          at_css('h2').name = 'h1'
+        end
+
+        css('pre').each do |node|
+          node.content = node.content
+        end
+
+        doc
+      end
+    end
+  end
+end

--- a/lib/docs/filters/docker/entries.rb
+++ b/lib/docs/filters/docker/entries.rb
@@ -1,0 +1,22 @@
+module Docs
+  class Docker
+    class EntriesFilter < Docs::EntriesFilter
+      def get_name
+        title = at_css('h1').content
+
+        title = title.split(' — ').first
+        title = title.split(' - ').first
+
+        title
+      end
+
+      def get_type
+        if slug.count('/') == 1 or slug.count('/') == 2
+           slug.split('/').first.capitalize
+        else
+          slug.split('/')[0...-1].map(&:capitalize).join('/').gsub(/\-|\_/, ' ')
+        end
+      end
+    end
+  end
+end

--- a/lib/docs/scrapers/docker.rb
+++ b/lib/docs/scrapers/docker.rb
@@ -1,0 +1,42 @@
+module Docs
+  class Docker < UrlScraper
+    self.name = 'Docker'
+    self.slug = 'docker'
+    self.type = 'docker'
+
+    self.links = {
+      home: 'https://docker.com/',
+      code: 'https://github.com/docker/docker'
+    }
+
+    html_filters.push 'docker/clean_html', 'docker/entries'
+
+    options[:trailing_slash] = true
+
+    options[:only_patterns] = [
+      /\Aengine\//,
+      /\Acompose\//,
+      /\Amachine\//,
+      /\Aswarm\//
+    ]
+
+    options[:skip] = [
+      "engine/installation/ubuntulinux/" # invalid document
+    ]
+
+    options[:attribution] = <<-HTML
+      &copy; 2016 Docker Inc.<br>
+      Licensed under the Apache 2 License.
+    HTML
+
+    version '1.11' do
+      self.release = '1.11'
+      self.base_url = "https://docs.docker.com/v#{self.version}/"
+    end
+
+    version '1.10' do
+      self.release = '1.10'
+      self.base_url = "https://docs.docker.com/v#{self.version}/"
+    end
+  end
+end

--- a/public/icons/docs/docker/SOURCE
+++ b/public/icons/docs/docker/SOURCE
@@ -1,0 +1,1 @@
+https://www.docker.com/brand-guidelines


### PR DESCRIPTION
The docker docs includes both their Free/Open Source Software tools as well as their proprietary ones. This scraper only includes the FOSS ones.