### PR TITLE
Add Bottle Documentation

### DIFF
--- a/assets/stylesheets/pages/_sphinx.scss
+++ b/assets/stylesheets/pages/_sphinx.scss
@@ -19,7 +19,7 @@
 
   ul.simple { margin: 1em 0; }
 
-  h2 > a, h3 > a, dt[id] > a.external { float: right; }
+  h2 > a, h3 > a, dt[id] > a.external, dt[id] > a.internal { float: right; }
 
   .admonition-title {
     float: left;

--- a/lib/docs/filters/bottle/entries.rb
+++ b/lib/docs/filters/bottle/entries.rb
@@ -1,0 +1,59 @@
+module Docs
+  class Bottle
+    class EntriesFilter < Docs::EntriesFilter
+      TYPES = {
+        'routing' => 'Request Routing',
+        'stpl' => 'SimpleTemplate Engine',
+        'api'  => 'API Reference',
+
+        'tutorial_app' => 'Tutorial',
+        'async' => 'Primer to Asynchronous Applications',
+        'faq' => 'Frequently Asked Questions'
+      }
+
+      def get_name
+        name = at_css('h1').content.strip
+        name.remove! "\u{00B6}"
+        name
+      end
+
+      def get_type
+        type = slug.split('/').first
+
+        if TYPES.key?(type)
+          type = TYPES[type]
+        else
+          type = type.capitalize
+        end
+
+        type
+      end
+
+      def additional_entries
+        entries = []
+
+        css('.class').each do |node|
+          class_name = node.at_css('dt > .descname').content
+          class_id = node.at_css('dt[id]')['id']
+          entries << [class_name, class_id]
+
+          node.css('.method').each do |n|
+            next unless n.at_css('dt[id]')
+            name = n.at_css('.descname').content
+            name = "#{class_name}::#{name}()"
+            id = n.at_css('dt[id]')['id']
+            entries << [name, id]
+          end
+        end
+
+        css('.function').each do |node|
+          name = "#{node.at_css('.descname').content}()"
+          id = node.at_css('dt[id]')['id']
+          entries << [name, id]
+        end
+
+        entries
+      end
+    end
+  end
+end

--- a/lib/docs/scrapers/bottle.rb
+++ b/lib/docs/scrapers/bottle.rb
@@ -1,0 +1,37 @@
+module Docs
+  class Bottle < FileScraper
+    self.type = 'sphinx'
+    self.dir = ""
+    self.root_path = "index.html"
+    self.links = {
+      home: 'https://bottle.org/',
+      code: 'https://github.com/bottlepy/bottle'
+    }
+
+    html_filters.push 'bottle/entries', 'sphinx/clean_html'
+
+    options[:container] = '.body'
+
+    options[:skip] = %w(
+      changelog.html
+      development.html
+      plugindev.html
+      _modules/bottle.html
+    )
+
+    options[:attribution] = <<-HTML
+      &copy; 2009&ndash;2016, Marcel Hellkamp<br>
+      Licensed under the MIT License.<br>
+    HTML
+
+    version '0.12' do # http://bottlepy.org/docs/0.12/bottle-docs.zip
+      self.release = '0.12'
+      self.base_url = "http://bottlepy.org/docs/#{self.version}/"
+    end
+
+    version '0.11' do # http://bottlepy.org/docs/0.11/bottle-docs.zip
+      self.release = '0.11'
+      self.base_url = "http://bottlepy.org/docs/#{self.version}/"
+    end
+  end
+end


### PR DESCRIPTION
The URLs where bottle documentation can be downloaded are included in the scraper.

A very nice PNG version of the icon can be found in the `/_static/` directory of the zip file.

A note, while he documentation is MIT, [the icon](http://bottlepy.org/docs/dev/index.html#license) isn't and may require permission.