### PR TITLE
Add MathML CSS fallback

### DIFF
--- a/assets/javascripts/vendor/mathml.js
+++ b/assets/javascripts/vendor/mathml.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
+ * Adapted from: https://github.com/fred-wang/mathml.css */
+/*jslint browser: true*/
+
+(function () {
+    "use strict";
+    window.addEventListener("load", function () {
+        var box, div, link, namespaceURI;
+        // First check whether the page contains any <math> element.
+        namespaceURI = "http://www.w3.org/1998/Math/MathML";
+        // Create a div to test mspace, using Kuma's "offscreen" CSS
+        document.body.insertAdjacentHTML("afterbegin", "<div style='border: 0; clip: rect(0 0 0 0); height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; width: 1px;'><math xmlns='" + namespaceURI + "'><mspace height='23px' width='77px'></mspace></math></div>");
+        div = document.body.firstChild;
+        box = div.firstChild.firstChild.getBoundingClientRect();
+        document.body.removeChild(div);
+        if (Math.abs(box.height - 23) > 1  || Math.abs(box.width - 77) > 1) {
+            // Insert the mathml.css stylesheet.
+            link = document.createElement("link");
+            link.href = "http://fred-wang.github.io/mathml.css/mathml.css";
+            link.rel = "stylesheet";
+            document.head.appendChild(link);
+        }
+    });
+}());


### PR DESCRIPTION
As indicated in e.g. #331, MathML is not supported in DevDocs in unsupported browsers such as Chrome.  This PR uses the same CSS fallback [Mozilla uses](https://developer.cdn.mozilla.net/static/styles/libs/mathml.css) in their docs, that originates from this repo [fred-wang/mathml.css](https://github.com/fred-wang/mathml.css): example [Math.PI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/PI) This method is doc-agnostic, so will also work for all other docs that uses MathML. 

Process is as follows:
 1. Check for MathML support
 2. Sideload CSS if not existent

This method saves bandwidth and is thus faster if MathML is supported. However, currently it sideloads the CSS externally.

2 possible alternatives:
 1. Sideload the CSS locally (couldn't figure out how to do that in the set-up of DevDocs, unfortunatly)
 2. Alter the css with a `.fallback` class, include in `application.css.scss` and apply class if not supported. However, the docs are not present on load so applying the class makes it difficult.

Whilst [MathJax](https://www.mathjax.org/) provides much better support, it is rather immense...

Feedback is welcome.