### PR TITLE
iPython+notebook syntax highlighting and allowing data:image uris

### DIFF
--- a/lib/docs/filters/core/normalize_urls.rb
+++ b/lib/docs/filters/core/normalize_urls.rb
@@ -11,6 +11,7 @@ module Docs
 
     def update_attribute(tag, attribute)
       css(tag.to_s).each do |node|
+        next if node[attribute].start_with?('data:image')
         next unless value = node[attribute]
         next if fragment_url_string?(value)
         node[attribute] = normalize_url(value)

--- a/lib/docs/filters/sphinx/clean_html.rb
+++ b/lib/docs/filters/sphinx/clean_html.rb
@@ -20,10 +20,18 @@ module Docs
         css('div[class*="highlight-"]').each do |node|
           pre = node.at_css('pre')
           pre.content = pre.content
-          pre['data-language'] = node['class'][/highlight\-(\w+)/, 1]
-          pre['data-language'] = 'php' if pre['data-language'] == 'ci'
-          pre['data-language'] = 'markup' if pre['data-language'] == 'html+django'
-          pre['data-language'] = 'python' if pre['data-language'] == 'default' || pre['data-language'].start_with?('python')
+          lang = node['class'][/highlight\-(\w+)/, 1]
+          lang = 'php' if lang == 'ci'
+          lang = 'markup' if lang == 'html+django'
+          lang = 'python' if lang == 'default' || lang.start_with?('python') || lang.start_with?('ipython')
+          pre['data-language'] = lang
+          node.replace(pre)
+        end
+
+        # Support code blocks in jupyter notebook files
+        css('.code_cell div.highlight').each do |node|
+          pre = node.at_css('pre')
+          pre['data-language'] = 'python'
           node.replace(pre)
         end
 


### PR DESCRIPTION
In some python-based documentation, jupyter notebook or iPython code cells are used. These are not properly recognised by the sphinx html cleaner. Example: http://devdocs.io/pandas~0.18/10min

Additionally, such notebooks may contain data:image URIs for images, which are currently replaced by '#' as those are deemed invalid. This fix simply skips any sanitising for these.