### PR TITLE
[WIP] First exportable version of sequel

### DIFF
--- a/lib/docs/filters/sequel/clean_html.rb
+++ b/lib/docs/filters/sequel/clean_html.rb
@@ -1,0 +1,60 @@
+module Docs
+  class Sequel
+    class CleanHtmlFilter < Filter
+      def call
+        # css('.summary_toggle', '.inheritanceTree', 'h1 .note', '.source_code', '.box_info dl:last-child').remove
+        # css('a[href*="travis"]', 'a[href*="gemnasium"]', 'a[href*="codeclimate"]', 'a[href*="gitter"]').remove if root_page?
+        #
+        # css('.signature').each do |node|
+        #   node.name = 'h3'
+        # end
+        #
+        # css('.permalink', 'div.docstring', 'div.discussion', '.method_details_list', '.attr_details',
+        #     'h3 strong', 'h3 a', 'h3 tt', 'h3 span', 'div.inline p', 'div.inline').each do |node|
+        #   node.before(node.children).remove
+        # end
+        #
+        # css('.tag_title').each do |node|
+        #   node.name = 'h4'
+        # end
+        #
+        # css('span.summary_signature', 'tt', '.tags span.name').each do |node|
+        #   node.name = 'code'
+        #   node.inner_html = node.inner_html.strip
+        # end
+        #
+        # css('code > a').each do |node|
+        #   node.inner_html = node.inner_html.strip
+        # end
+        #
+        # css('pre.code').each do |node|
+        #   node.content = node.content
+        #   node['data-language'] = 'ruby'
+        # end
+        css('hr').remove
+
+        # Remove paragraph/up links
+        css('h1 > span', 'h2 > span', 'h3 > span', 'h4 > span', 'h5 > span', 'h6 > span').remove
+
+        # Move id attributes to headings, TODO: Probably doesn't work
+        css('.method-detail').each do |node|
+          next unless heading = node.at_css('.method-heading')
+          heading['id'] = node['id']
+          node.remove_attribute 'id'
+        end
+
+        # Convert "click to toggle source" into a link
+        css('.source-toggle').each do |node|
+          node.name = 'a'
+          node.content = 'Show source'
+        end
+
+        # Remove code highlighting
+        css('pre').each do |node|
+          node.content = node.content
+        end
+        doc
+      end
+    end
+  end
+end

--- a/lib/docs/filters/sequel/entries.rb
+++ b/lib/docs/filters/sequel/entries.rb
@@ -1,0 +1,29 @@
+module Docs
+  class Sequel
+    class EntriesFilter < Docs::Rdoc::EntriesFilter
+      def get_name
+        at_css('h1').content.split(' ').last.split('::')[1]
+      end
+
+      def get_type
+        at_css('h1').content.split(' ').last.sub("Sequel::","")
+      end
+
+      def additional_entries
+        return [] if initial_page?
+
+        css('.signature').each_with_object [] do |node, entries| # Doesn't work, problems with css class
+          next if node.ancestors('.overload').present?
+          name = node.content.strip
+          name.remove! %r{[\s\(].*}
+          name.prepend(self.name)
+          entries << [name, node['id']]
+        end
+      end
+
+      def include_default_entry?
+        !initial_page?
+      end
+    end
+  end
+end

--- a/lib/docs/scrapers/sequel.rb
+++ b/lib/docs/scrapers/sequel.rb
@@ -1,0 +1,17 @@
+module Docs
+  class Sequel < UrlScraper
+    self.slug = 'sequel'
+    self.type = 'rdoc'
+    self.release = '4.41.0'
+    self.base_url = 'http://sequel.jeremyevans.net/rdoc/classes/'
+    self.root_path = 'Sequel.html'
+
+
+    html_filters.push 'sequel/clean_html', 'sequel/entries'
+    options[:container] = '#wrapper'
+
+    options[:attribution] = <<-HTML
+      Copyright &copy; 2007-2008 Sharon Rosner Copyright © 2008-2016 Jeremy Evans
+    HTML
+  end
+end

--- a/public/docs/docs.json
+++ b/public/docs/docs.json
@@ -1,1 +1,1 @@
-[]
+[{"name":"Sequel","slug":"sequel","type":"rdoc","release":"4.41.0","mtime":1481800882,"db_size":1254035}]


### PR DESCRIPTION
For quick export and generate sequel devdocs you need to execute
thor docs:generate sequel --force --debug
Docs don't look so nice, but the main part of exporting is done. Now it’s the time for analyze rdoc source code and rewrite actual filters.