### PR TITLE
Rustdoc scraper: add rule to remove "Run" links

### DIFF
--- a/lib/docs/filters/rust/clean_html.rb
+++ b/lib/docs/filters/rust/clean_html.rb
@@ -11,6 +11,7 @@ module Docs
         end
 
         css('.rusttest', 'hr').remove
+        css('pre > .test-arrow').remove
 
         css('.docblock > h1').each { |node| node.name = 'h4' }
         css('h2.section-header').each { |node| node.name = 'h3' }


### PR DESCRIPTION
All over the Rust docs, there's this problem:

![screenshot](http://i.imgur.com/psGETj9.png)

It obviously comes from the live-test "Run" button in the original docs:

![screenshot](http://i.imgur.com/srIMvyF.png)

Hence, this commit filters out the `test-arrow` links to fix the problem.