### PR TITLE
core/doc: cleanup slug when based on name.

### DIFF
--- a/lib/docs/core/doc.rb
+++ b/lib/docs/core/doc.rb
@@ -48,7 +48,10 @@ module Docs
       end
 
       def slug
-        slug = @slug || name.try(:downcase)
+        slug = @slug || (
+          raise "Slug must be set explicitly when name (#{name}) consists of anything else than [\\w\\.%]" if /[^\w\.%]/ =~ name
+          name.try(:downcase)
+        )
         version? ? "#{slug}~#{version_slug}" : slug
       end
 

--- a/test/lib/docs/core/doc_test.rb
+++ b/test/lib/docs/core/doc_test.rb
@@ -55,6 +55,18 @@ class DocsDocTest < MiniTest::Spec
       doc.version = '42'
       assert_equal 'foo~42', doc.slug
     end
+
+    it "returns 'foobar' when #name has been set to 'FooBar'" do
+      doc.name = 'FooBar'
+      assert_equal 'foobar', doc.slug
+    end
+
+    it "raises error when #name has unsluggable characters" do
+      assert_raises do
+        doc.name = 'Foo-Bar'
+        doc.slug
+      end
+    end
   end
 
   describe ".slug=" do


### PR DESCRIPTION
If I let the doc slug use the default, by downcasing the doc name, we might as well clean it up so it is routable.

As it is, if the name has a dash in it, it breaks if you try to load a page from the doc directly (it still works when browsing it by js navigation).
