### PR TITLE
Add an issue template for Github

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Before posting this issue, please take note of the following rule :
+    - If you are going to request a new set of documentation or an upgrade of 
+      an existing set, go to the Trello Board (https://trello.com/b/6BmTulfx/devdocs-documentation) instead.
+      The issue tracker is used only for issues.
+-->
+      
+### Environment
+
+OS & Browser/version :
+
+### Subject
+
+<!-- Explain your problem here -->
+
+### Step to reproduce
+
+<!-- List here the steps to reproduce your problem -->


### PR DESCRIPTION
Add an issue template for Github so that new issues warns the reporter that an issue for a new documentation set is not valid.