### PR TITLE
Responsive browser compatibility tables

### DIFF
--- a/assets/stylesheets/components/_mobile.scss
+++ b/assets/stylesheets/components/_mobile.scss
@@ -105,6 +105,12 @@
     max-width: none;
     margin-left: 0;
   }
+  
+  // Responsive browser compatibility tables
+  #compat-desktop,
+  #compat-mobile {
+    overflow-x: auto;
+  }
 }
 
 //


### PR DESCRIPTION
[Source page](http://devdocs.io/javascript/global_objects/int8array)

The table does not fit completely into the screen on mobile, and a horizontal scroll appears:
![image](https://cloud.githubusercontent.com/assets/4408379/24470394/751671f2-14c7-11e7-8881-72b9632dc7de.png)

The solution is to add `overflow-y: auto;` (look more [here](http://maxdesign.com.au/articles/simple-responsive-table/)) to the container with the table, then the horizontal scroll will be only at the container, and not at the page:
![image](https://cloud.githubusercontent.com/assets/4408379/24470465/ab7614be-14c7-11e7-9ccc-f5b940053a49.png)

_Note: above in the screenshot you can not see the horizontal bars, but they are when you hover._

Probably hurried with the PR. Can be so conceived, but it looks like a bug.
