### PR TITLE
Improve Dockerfile, and added alpine version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+test
+Dockerfile*
+.gitignore
+.dockerignore
+.travis.yml
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ WORKDIR /devdocs
 
 RUN apt-get update && \
     apt-get -y install git nodejs && \
-    gem install bundler
+    gem install bundler && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY Gemfile Gemfile.lock Rakefile /devdocs/
 
-RUN bundle install --system
+RUN bundle install --system && \
+    rm -rf ~/.gem /root/.bundle/cache /usr/local/bundle/cache
 
 COPY . /devdocs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,21 @@
-
 FROM ruby:2.4.1
 MAINTAINER Conor Heine <conor.heine@gmail.com>
 
-RUN apt-get update
-RUN apt-get -y install git nodejs
-COPY . /devdocs
-RUN gem install bundler
-
 WORKDIR /devdocs
 
+RUN apt-get update && \
+    apt-get -y install git nodejs && \
+    gem install bundler
+
+COPY Gemfile Gemfile.lock Rakefile /devdocs/
+
 RUN bundle install --system
-RUN thor docs:download --all
+
+COPY . /devdocs
+
+RUN thor docs:download --all && \
+    thor assets:compile && \
+    rm -rf /tmp
 
 EXPOSE 9292
 CMD rackup -o 0.0.0.0
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ruby:2.4.1
-MAINTAINER Conor Heine <conor.heine@gmail.com>
 
 WORKDIR /devdocs
 

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -11,7 +11,8 @@ RUN apk --update add nodejs build-base libstdc++ gzip git zlib-dev && \
     thor docs:download --all && \
     thor assets:compile && \
     apk del gzip build-base git zlib-dev && \
-    rm -rf /var/cache/apk/* && rm -rf /tmp && rm -rf ~/.gem
+    rm -rf /var/cache/apk/* /tmp ~/.gem /root/.bundle/cache \
+    /usr/local/bundle/cache /usr/lib/node_modules
 
 EXPOSE 9292
 CMD rackup -o 0.0.0.0

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,0 +1,17 @@
+FROM ruby:2.4.1-alpine
+MAINTAINER Conor Heine <conor.heine@gmail.com>
+
+WORKDIR /devdocs
+
+COPY . /devdocs
+
+RUN apk --update add nodejs build-base libstdc++ gzip git zlib-dev && \
+    gem install bundler && \
+    bundle install --system --without test && \
+    thor docs:download --all && \
+    thor assets:compile && \
+    apk del gzip build-base git zlib-dev && \
+    rm -rf /var/cache/apk/* && rm -rf /tmp && rm -rf ~/.gem
+
+EXPOSE 9292
+CMD rackup -o 0.0.0.0

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -6,7 +6,7 @@ COPY . /devdocs
 
 RUN apk --update add nodejs build-base libstdc++ gzip git zlib-dev && \
     gem install bundler && \
-    bundle install --system --without test --no-document && \
+    bundle install --system --without test && \
     thor docs:download --all && \
     thor assets:compile && \
     apk del gzip build-base git zlib-dev && \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,5 +1,4 @@
 FROM ruby:2.4.1-alpine
-MAINTAINER Conor Heine <conor.heine@gmail.com>
 
 WORKDIR /devdocs
 
@@ -7,7 +6,7 @@ COPY . /devdocs
 
 RUN apk --update add nodejs build-base libstdc++ gzip git zlib-dev && \
     gem install bundler && \
-    bundle install --system --without test && \
+    bundle install --system --without test --no-document && \
     thor docs:download --all && \
     thor assets:compile && \
     apk del gzip build-base git zlib-dev && \


### PR DESCRIPTION
- Added docker ignore to remove unnecessary files
- Reduce number of layers, and optimise build speed (e.g. don't re-download gem files on every file change)
- Add alpine version to reduce size
- By deleting `/tmp` it reduces the size from ~4GB to ~2GB
