### PR TITLE
Remove trailing slash on bootstrap example URL

### DIFF
--- a/lib/docs/filters/bootstrap/clean_html_v3.rb
+++ b/lib/docs/filters/bootstrap/clean_html_v3.rb
@@ -27,7 +27,7 @@ module Docs
             node.remove_attribute('data-example-id')
             prev = node.previous_element
             prev = prev.previous_element until prev['id']
-            node.inner_html = %(<a href="#{current_url}/##{prev['id']}">Open example on getbootstrap.com</a>)
+            node.inner_html = %(<a href="#{current_url}##{prev['id']}">Open example on getbootstrap.com</a>)
           end
         end
 

--- a/lib/docs/filters/bootstrap/clean_html_v4.rb
+++ b/lib/docs/filters/bootstrap/clean_html_v4.rb
@@ -26,7 +26,7 @@ module Docs
             node.remove_attribute('data-example-id')
             prev = node.previous_element
             prev = prev.previous_element until prev['id']
-            node.inner_html = %(<a href="#{current_url}/##{prev['id']}">Open example on getbootstrap.com</a>)
+            node.inner_html = %(<a href="#{current_url}##{prev['id']}">Open example on getbootstrap.com</a>)
           end
         end
 


### PR DESCRIPTION
On Bootstrap 3.3 generated docs, the "Open example on getbootstrap.com" links have extra slash that breaks the destination website:

<img width="652" alt="screen shot 2017-11-22 at 1 05 24 pm" src="https://user-images.githubusercontent.com/157515/33114757-dc010c04-cf90-11e7-99bd-ad4af95e71b2.png">

It is okay on Bootstrap 4, though.

This PR removes the trailing slash. It fixes version 3.3 and doesn't have any impact on version 4.